### PR TITLE
changing names for lin and quad components in datacard

### DIFF
--- a/DatacardCreator/datacard_creator_2.cpp
+++ b/DatacardCreator/datacard_creator_2.cpp
@@ -145,8 +145,8 @@ int main (int argc, char ** argv)
           TH1F * h_QU = hmap_QU.at (iHisto->first) ;
 
           map<string, TH1F *> h_eftInputs ;
-          h_eftInputs["linear_" + wilson_coeff_names.at (iCoeff)]      = h_LI ;
-          h_eftInputs["quadratic_" + wilson_coeff_names.at (iCoeff)]   = h_QU ;
+          h_eftInputs["lin_" + wilson_coeff_names.at (iCoeff)]      = h_LI ;
+          h_eftInputs["quad_" + wilson_coeff_names.at (iCoeff)]   = h_QU ;
 
           vector<string> active_coeffs ; 
           active_coeffs.push_back (wilson_coeff_names.at (iCoeff)) ;


### PR DESCRIPTION
Ho modificato i nomi delle componenti lineare e quadratica create nella datacard in accordo con il modello di Combine (AnomalousCouplingEFT:analiticAnomalousCouplingEFT).